### PR TITLE
Fix use of animated.event in order to make native driver to work properly

### DIFF
--- a/CommentListItem.js
+++ b/CommentListItem.js
@@ -36,6 +36,7 @@ export default class CommentListItem extends React.PureComponent {
           </Text>
 
           <BorderlessButton
+            borderless={false}
             onPress={() => alert('user!')}
             style={{ marginTop: 15 }}>
             <Text style={styles.lockup}>
@@ -47,6 +48,7 @@ export default class CommentListItem extends React.PureComponent {
           </BorderlessButton>
 
           <BorderlessButton
+            borderless={false}
             onPress={() => alert('post!')}
             style={{ marginTop: 5 }}>
             <Text style={styles.response}>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"dependencies": {
 		"react": "16.0.0-alpha.12",
 		"react-native": "0.47.1",
-		"react-native-gesture-handler": "^1.0.0-alpha.7",
+		"react-native-gesture-handler": "^1.0.0-alpha.9",
 		"react-native-swipeout": "^2.2.2",
 		"uuid": "^3.1.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -3202,9 +3202,9 @@ react-devtools-core@2.3.1:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
-react-native-gesture-handler@^1.0.0-alpha.7:
-  version "1.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0-alpha.7.tgz#7bbcd7d687269bb1fe0ac38e6bc8ac74e56c68bc"
+react-native-gesture-handler@^1.0.0-alpha.9:
+  version "1.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0-alpha.9.tgz#87a9b1e29cab815194dc3b039fffb30b08813055"
 
 react-native-swipeout@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
This changes a few things:

1. Upgrades to RNGH alpha.9 which has a few fixes (including problem with occlusion on android, support for ripple background color and a couple of unrelated bugfixes)
2. Sets `borderless={false}` for inline text buttons so that the ripple effect is bound and doesn't animate filling the whole row
3. Add "resistance" to the left bound of the swiping row (like when we swipe left it follows the finger until we reach ActionsVisibleX and then since there is nothing else to reveal we add some resistance) 
4. Update `Animated` related code for handling pan responder. Previously the issue with animation jumping a bit when starting from non-zero offset was cause by the fact that until the animation settles the offset wan't updated. Then when we started another pan it would reset translateX to zero (because the animation was interrupted) and only after slight delay we'd update the offset. It worked with native driver disabled as the event that stops the animation and animation finish callback run in the same JS loop. To account for this we need to have two animated values, one for translation that comes from pan (starting from 0 each time we start a new gesture) and another value that would be used for animating and for keeping a proper offset. Then the resulting translateX for the row is calculated as a sum of the values. Then when the gesture is over we reset drag-related value to 0 (so that we are prepared for it starting from 0 next time when we start the pan) and accumulate the offset in the other value.